### PR TITLE
feat: Handle benchmark and proof submission errors

### DIFF
--- a/tig-benchmarker/src/benchmarker/mod.rs
+++ b/tig-benchmarker/src/benchmarker/mod.rs
@@ -5,6 +5,7 @@ mod query_data;
 mod setup_job;
 mod submit_benchmark;
 mod submit_proof;
+mod utils;
 
 #[cfg(not(feature = "cuda"))]
 pub mod run_benchmark;

--- a/tig-benchmarker/src/benchmarker/query_data.rs
+++ b/tig-benchmarker/src/benchmarker/query_data.rs
@@ -51,7 +51,7 @@ pub async fn execute() -> Result<QueryData> {
     Ok(cache.get(&latest_block_id).unwrap().clone())
 }
 
-async fn query_latest_block() -> Result<Block> {
+pub async fn query_latest_block() -> Result<Block> {
     let GetBlockResp { block, .. } = api()
         .get_block(GetBlockReq {
             id: None,

--- a/tig-benchmarker/src/benchmarker/submit_proof.rs
+++ b/tig-benchmarker/src/benchmarker/submit_proof.rs
@@ -1,5 +1,4 @@
-use super::{api, Result};
-use crate::future_utils::sleep;
+use super::{api, Result, utils::handle_submission_error, query_data::query_latest_block};
 use tig_api::SubmitProofReq;
 use tig_worker::SolutionData;
 
@@ -10,6 +9,9 @@ pub async fn execute(benchmark_id: String, solutions_data: Vec<SolutionData>) ->
         benchmark_id,
         solutions_data,
     };
+
+    let mut current_height = query_latest_block().await?.details.height;
+
     for attempt in 1..=MAX_RETRIES {
         println!("Submission attempt {} of {}", attempt, MAX_RETRIES);
         match api().submit_proof(req.clone()).await {
@@ -20,11 +22,11 @@ pub async fn execute(benchmark_id: String, solutions_data: Vec<SolutionData>) ->
                 }
             }
             Err(e) => {
-                let err_msg = format!("Failed to submit proof: {:?}", e);
+                let err_msg = format!("Failed to submit proof after {} attempts: {:?}", attempt, e);
                 if attempt < MAX_RETRIES {
-                    println!("{}", err_msg);
-                    println!("Retrying in 5 seconds...");
-                    sleep(5000).await;
+                    if !handle_submission_error(&e, "proof", &mut current_height).await {
+                        return Err(err_msg);
+                    }
                 } else {
                     return Err(err_msg);
                 }

--- a/tig-benchmarker/src/benchmarker/utils.rs
+++ b/tig-benchmarker/src/benchmarker/utils.rs
@@ -1,0 +1,49 @@
+use super::query_data::query_latest_block;
+use crate::future_utils::sleep;
+use std::time::Instant;
+
+const WAIT_TIME_MS: u32 = 5000;
+const LOG_INTERVAL_SECS: u64 = 10;
+
+pub async fn handle_submission_error(e: &anyhow::Error, submit_name: &str, current_height: &mut u32) -> bool {
+    let err_msg = format!("Failed to submit {}: {:?}", submit_name, e);
+    
+    if let Some(err_str) = e.downcast_ref::<String>() {
+        if err_str.to_lowercase().contains("high transaction volume") {
+            println!("High transaction volume detected. Waiting for a new block...");
+
+            let start_time = Instant::now();
+            let mut last_log_time = start_time;
+            loop {
+                sleep(WAIT_TIME_MS).await;
+                let elapsed_time = start_time.elapsed();
+                let time_since_last_log = last_log_time.elapsed();
+
+                let new_height = query_latest_block().await.expect("Failed to query latest block").details.height;
+                if new_height > *current_height {
+                    *current_height = new_height;
+                    println!("New block {} mined after waiting for {} seconds. Retrying submission...", 
+                             current_height, elapsed_time.as_secs());
+                    break;
+                } else if time_since_last_log.as_secs() >= LOG_INTERVAL_SECS {
+                    last_log_time = Instant::now();
+                    println!("Waiting for a new block... ({} seconds elapsed)", elapsed_time.as_secs());
+                } else {
+                    /* Do Nothing */
+                }
+            }
+        } else if err_str.to_lowercase().contains("proof already submitted") {
+            return false;
+        } else {
+            println!("{}", err_msg);
+            println!("Retrying in {} seconds...", WAIT_TIME_MS / 1000);
+            sleep(WAIT_TIME_MS).await;
+        }
+    } else {
+        println!("{}", err_msg);
+        println!("Retrying in {} seconds...", WAIT_TIME_MS / 1000);
+        sleep(WAIT_TIME_MS).await;
+    }
+
+    true
+}


### PR DESCRIPTION
When submitting a benchmark or proof, if a `high transaction volume error` occurs,
the algorithm waits until a new block is mined before retrying.
If a `proof already submitted` error occurs, the submission will not be repeated.
Added more descriptive logs to enhance the clarity of the submission process.